### PR TITLE
ci: add secret-scan workflow + gitleaks allowlist config

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,64 @@
+name: Secret scan (gitleaks)
+
+# GitHub Advanced Security secret scanning is not available on Free plan
+# private repos. This workflow self-hosts the same protection using gitleaks.
+# Runs on every push, pull request, weekly drift detection, and on demand.
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Weekly Monday 06:00 UTC — catches secrets that may have been added
+    # without the workflow running (e.g., through a forgotten branch).
+    - cron: '0 6 * * 1'
+
+# Minimum permissions: only read the repo contents.
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        # actions/checkout v4.3.1 — pinned to commit SHA to defend against
+        # tag-spoofing supply-chain attacks. Update via Dependabot weekly.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # Full git history so gitleaks can scan every commit ever made,
+          # not just the latest one.
+          fetch-depth: 0
+
+      - name: Install gitleaks (verified against published checksums)
+        env:
+          GITLEAKS_VERSION: '8.30.1'
+        run: |
+          set -euo pipefail
+          cd /tmp
+          curl -sSfL -O "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL -O "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          # Verify the binary against the publisher's signed checksums.
+          sha256sum --check --ignore-missing "gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          tar -xzf "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan working tree + entire git history
+        run: |
+          # --log-opts="--all -p" → scan ALL refs (not just current branch)
+          # --redact → never print actual secret values to logs
+          # --no-banner → cleaner CI output
+          # --verbose → show file:line for each finding
+          # --exit-code 1 → fail the job if any secret is found
+          gitleaks git \
+            --log-opts="--all -p" \
+            --redact \
+            --no-banner \
+            --verbose \
+            --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+title = "ArabicTeleprompter Gitleaks Config"
+
+# Inherit all gitleaks built-in rules (AWS, GCP, Azure, GitHub/GitLab PATs,
+# Stripe, Slack, generic high-entropy strings, RSA/EC keys, etc.). Without
+# this line, gitleaks auto-discovers this file and loads an EMPTY ruleset —
+# every scan silently passes. Established during the 2026-04-19 org sweep.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known non-secret infrastructure identifiers"
+paths = [
+  '''docs/.*\.md''',
+  '''CLAUDE\.md''',
+]


### PR DESCRIPTION
Closes this repo's secret-scan coverage gap in the org-wide gitleaks rollout (2026-04-19).

## What this adds

- `.gitleaks.toml` — inherits default rules (`useDefault = true`) and allowlists paths that are known to contain placeholder tokens in docs. The `useDefault = true` line is load-bearing — without it, gitleaks silently loads an empty ruleset and every scan falsely passes.
- `.github/workflows/secret-scan.yml` — self-hosted gitleaks scan (GitHub Advanced Security secret scanning is only on paid plans for private repos). Runs on every push, every PR, weekly Monday cron, and on-demand via `workflow_dispatch`. Scans full git history, not just HEAD.

## Context

Pattern is already in use and verified on `AlsheikhMedia/alsheikhmedia.com` and `AlsheikhMedia/helpyard.ae`. This PR brings this repo to parity. No code changes — config only.