### PR TITLE
chore: add .worktrees/ and internal/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target
 .env
 .env.*
 !.env.example
+.worktrees/
+internal/


### PR DESCRIPTION
Git housekeeping: ignore worktree directories and Hermes internal files.